### PR TITLE
test(python): Add test that `register_all` does not error

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ geodatafusion = "0.1"
 
 ## Functions supported
 
+Functions are explicitly modeled after the [PostGIS API](https://postgis.net/docs/reference.html). We strive to match the PostGIS API as much as possible.
+
 ### Geometry Constructors
 
 | Name                  | Implemented | Description                                                                                                                |

--- a/python/python/geodatafusion/__init__.py
+++ b/python/python/geodatafusion/__init__.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from datafusion import udf
+from datafusion import udaf, udf
 
 from ._rust import *
 from ._rust import ___version
@@ -83,7 +83,8 @@ def register_all_native(ctx: SessionContext):
     ctx.register_udf(udf(native.ZMax()))
     ctx.register_udf(udf(native.MakeBox2D()))
     ctx.register_udf(udf(native.MakeBox3D()))
-    ctx.register_udf(udf(native.Extent()))
+    # https://github.com/apache/datafusion-python/issues/1237
+    ctx.register_udaf(udaf(native.Extent()))  # type: ignore
 
     # constructors
     ctx.register_udf(udf(native.Point()))

--- a/python/tests/test_example.py
+++ b/python/tests/test_example.py
@@ -1,2 +1,0 @@
-def test_hello_world():
-    print("Hello, world!")

--- a/python/tests/test_register.py
+++ b/python/tests/test_register.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from datafusion import SessionContext
+from geodatafusion import register_all
+
+
+def test_register_all():
+    # Ensure that register_all works without error
+    ctx = SessionContext()
+    register_all(ctx)


### PR DESCRIPTION
geodatafusion 0.1's `register_all` is broken because `Extent` is trying to be registered as a UDF while it's a UDAF.