### PR TITLE
fix: Merge all wheel artifacts into dist for publish discovery.

### DIFF
--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -228,6 +228,9 @@ jobs:
     needs: [macos, windows, linux]
     steps:
       - uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
 
       - uses: actions/setup-python@v6
         with:


### PR DESCRIPTION
The Pypi publish workflow step was failing with
```
FileNotFoundError: [Errno 2] No such file or directory: '/github/workspace/dist'
Warning:  It looks like there are no Python distribution packages to publish in the directory 'dist/'. Please verify that they are in place should you face this problem.
ERROR    InvalidDistribution: Cannot find file (or expand pattern): 'dist/*
```
This consolidates all the wheels into the `/dist` directory so they can be discovered by the publish workflow.