### PR TITLE
feat: Add ST_LineMerge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,10 +23,10 @@ jobs:
         with:
           components: rustfmt, clippy
       - uses: Swatinem/rust-cache@v2
-        - name: Install dependencies
-          run: |
-            sudo apt-get update
-            sudo apt-get install -y libgeos-dev
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libgeos-dev
       - name: Clippy
         run: cargo clippy --all-features --tests -- -D warnings
       - name: Check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,10 @@ jobs:
           submodules: "recursive"
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
-
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libgeos-dev
       # Note: in the future expand to all crates in the workspace
       - name: Test that docs build without warnings
         run: cargo doc --all-features --document-private-items

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,10 @@ jobs:
         with:
           components: rustfmt, clippy
       - uses: Swatinem/rust-cache@v2
+        - name: Install dependencies
+          run: |
+            sudo apt-get update
+            sudo apt-get install -y libgeos-dev
       - name: Clippy
         run: cargo clippy --all-features --tests -- -D warnings
       - name: Check

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -480,15 +480,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cmake"
-version = "0.1.58"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "comfy-table"
 version = "7.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1838,23 +1829,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "geos-src"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63ee625c548bdf7ead03c75779d156ddfe48dc57820d336eeb39407c19f9a3b5"
-dependencies = [
- "cmake",
-]
-
-[[package]]
 name = "geos-sys"
 version = "2.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48fc11f837935501a7beb10afd8ecec14e5180274acf87e5a36bf0f770485884"
 dependencies = [
- "geos-src",
  "libc",
- "link-cplusplus",
  "pkg-config",
  "semver",
 ]
@@ -2496,15 +2476,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "840db8cf39d9ec4dd794376f38acc40d0fc65eec2a8f484f7fd375b84602becd"
 dependencies = [
  "zlib-rs",
-]
-
-[[package]]
-name = "link-cplusplus"
-version = "1.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f78c730aaa7d0b9336a299029ea49f9ee53b0ed06e9202e8cb7db9bae7b8c82"
-dependencies = [
- "cc",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -424,9 +424,9 @@ checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
 
 [[package]]
 name = "cc"
-version = "1.2.41"
+version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac9fe6cdbb24b6ade63616c0a0688e45bb56732262c158df3c0c4bea4ca47cb7"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -477,6 +477,15 @@ checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
 dependencies = [
  "chrono",
  "phf",
+]
+
+[[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -1360,9 +1369,9 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.4"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52051878f80a721bb68ebfbc930e07b65ba72f2da88968ea5c06fd6ca3d3a127"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "fixedbitset"
@@ -1690,6 +1699,7 @@ dependencies = [
  "geoarrow-expr-geo",
  "geoarrow-schema",
  "geohash",
+ "geos",
  "object_store",
  "thiserror 1.0.69",
  "tokio",
@@ -1815,6 +1825,38 @@ dependencies = [
  "serde_json",
  "serde_with",
  "wkt 0.14.0",
+]
+
+[[package]]
+name = "geos"
+version = "11.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d13c464e56cc46077aa9bafef9a02e65610ddafb6347a26a306855e7a7d3133"
+dependencies = [
+ "geos-sys",
+ "libc",
+]
+
+[[package]]
+name = "geos-src"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63ee625c548bdf7ead03c75779d156ddfe48dc57820d336eeb39407c19f9a3b5"
+dependencies = [
+ "cmake",
+]
+
+[[package]]
+name = "geos-sys"
+version = "2.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48fc11f837935501a7beb10afd8ecec14e5180274acf87e5a36bf0f770485884"
+dependencies = [
+ "geos-src",
+ "libc",
+ "link-cplusplus",
+ "pkg-config",
+ "semver",
 ]
 
 [[package]]
@@ -2454,6 +2496,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "840db8cf39d9ec4dd794376f38acc40d0fc65eec2a8f484f7fd375b84602becd"
 dependencies = [
  "zlib-rs",
+]
+
+[[package]]
+name = "link-cplusplus"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f78c730aaa7d0b9336a299029ea49f9ee53b0ed06e9202e8cb7db9bae7b8c82"
+dependencies = [
+ "cc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ geodatafusion = { path = "rust/geodatafusion", version = "0.4.0" }
 geohash = "0.13.1"
 geojson = "0.24"
 geoparquet = "0.8.0"
+geos = { version = "11.1", default-features = false }
 http-range-client = { version = "0.9", default-features = false }
 object_store = "0.13.2"
 serde_json = "1"

--- a/DEVELOP.md
+++ b/DEVELOP.md
@@ -10,6 +10,7 @@ This is a Rust workspace with multiple crates:
     - Internally, each _provider_ of functions is organized in submodules:
         - `native/` - Operations that are natively implemented, without the use of other dependencies like `geo`
         - `geo/` - Operations implemented using the `geo` crate
+        - `geos/` - Operations implemented using the `geos` crate (bindings to the native GEOS library), gated behind the optional `geos` feature
         - `geohash/` - GeoHash encoding/decoding, using the `geohash` crate
 - `rust/geodatafusion-flatgeobuf` - FlatGeobuf format support
 - `rust/geodatafusion-geoparquet` - GeoParquet format support
@@ -104,7 +105,15 @@ Functions are organized by category in `rust/geodatafusion/src/udf/`:
 - `geo/processing/` - Processing functions (ST_Buffer, ST_Simplify)
 - `geo/relationships/` - Spatial relationships (ST_Intersects, etc.)
 - `geo/validation/` - Validation functions (ST_IsValid)
+- `geos/processing/` - GEOS-backed processing functions (ST_LineMerge)
 - `geohash/` - GeoHash functions
+
+### GEOS-backed functions
+
+Functions in the `geos/` provider link the [GEOS](https://libgeos.org/) library, and can be controlled via Cargo features:
+
+- `geos` - enables the GEOS-backed UDFs, linking the **system** GEOS library (requires GEOS >= 3.11).
+- `geos-static` - implies `geos` and builds a **bundled** GEOS from vendored source instead, so no system library is needed (requires a C++ compiler and CMake at build time).
 
 ### Code Style
 

--- a/DEVELOP.md
+++ b/DEVELOP.md
@@ -110,10 +110,25 @@ Functions are organized by category in `rust/geodatafusion/src/udf/`:
 
 ### GEOS-backed functions
 
-Functions in the `geos/` provider link the [GEOS](https://libgeos.org/) library, and can be controlled via Cargo features:
+Functions in the `geos/` provider link the [GEOS](https://libgeos.org/) library, and can be controlled via Cargo features.
 
-- `geos` - enables the GEOS-backed UDFs, linking the **system** GEOS library (requires GEOS >= 3.11).
-- `geos-static` - implies `geos` and builds a **bundled** GEOS from vendored source instead, so no system library is needed (requires a C++ compiler and CMake at build time).
+The version of GEOS required varies by UDF,
+so we expose cargo features with explicit minimum version numbers,
+like `geos-3_11` (GEOS >=3.11).
+
+#### GEOS linking
+
+This crate will try to link the system-provided GEOS library by default.
+If you want to statically link GEOS from a source build,
+add a direct dependency on the `geos` crate to your project,
+and enable the `static` feature like so:
+
+```toml
+geos = { version = "11.1.1", features = ["static"] }
+```
+
+If you're using cargo workspaces, make sure that
+the crates using geodatafusion directly reference `geos`.
 
 ### Code Style
 

--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ Functions are explicitly modeled after the [PostGIS API](https://postgis.net/doc
 | ST_FilterByM                |             | Removes vertices based on their M value                                                           |
 | ST_GeneratePoints           |             | Generates a multipoint of random points contained in a Polygon or MultiPolygon.                   |
 | ST_GeometricMedian          |             | Returns the geometric median of a MultiPoint.                                                     |
-| ST_LineMerge                |             | Return the lines formed by sewing together a MultiLineString.                                     |
+| ST_LineMerge                | ✅          | Return the lines formed by sewing together a MultiLineString.                                     |
 | ST_MaximumInscribedCircle   |             | Computes the largest circle contained within a geometry.                                          |
 | ST_LargestEmptyCircle       |             | Computes the largest circle not overlapping a geometry.                                           |
 | ST_MinimumBoundingCircle    |             | Returns the smallest circle polygon that contains a geometry.                                     |

--- a/rust/geodatafusion/Cargo.toml
+++ b/rust/geodatafusion/Cargo.toml
@@ -10,6 +10,13 @@ categories = { workspace = true }
 rust-version = { workspace = true }
 
 
+[features]
+# Enable GEOS-backed UDFs (e.g. ST_LineMerge).
+# Requires GEOS >= 3.11 for directed merge (the feature flag here opts in to v3.11 features).
+geos = ["dep:geos", "geos/v3_11_0"]
+# Build a bundled GEOS from vendored source instead of linking the system library.
+geos-static = ["geos", "geos/static"]
+
 [dependencies]
 arrow-arith = { workspace = true }
 arrow-array = { workspace = true }
@@ -21,6 +28,7 @@ geoarrow-array = { workspace = true }
 geoarrow-expr-geo = { workspace = true }
 geoarrow-schema = { workspace = true }
 geohash = { workspace = true }
+geos = { workspace = true, optional = true }
 thiserror = { workspace = true }
 wkt = { workspace = true }
 

--- a/rust/geodatafusion/Cargo.toml
+++ b/rust/geodatafusion/Cargo.toml
@@ -11,11 +11,12 @@ rust-version = { workspace = true }
 
 
 [features]
-# Enable GEOS-backed UDFs (e.g. ST_LineMerge).
-# Requires GEOS >= 3.11 for directed merge (the feature flag here opts in to v3.11 features).
-geos = ["dep:geos", "geos/v3_11_0"]
-# Build a bundled GEOS from vendored source instead of linking the system library.
-geos-static = ["geos", "geos/static"]
+# Enables GEOS-backed UDFs.
+# We only use explicitly versioned flags,
+# and the structure should be recursive
+# (with higher version targets implying lower version ones
+# in a chain.)
+geos-3_11 = ["geos/v3_11_0"]
 
 [dependencies]
 arrow-arith = { workspace = true }

--- a/rust/geodatafusion/src/data_types.rs
+++ b/rust/geodatafusion/src/data_types.rs
@@ -7,7 +7,7 @@ use geoarrow_schema::{
     MultiLineStringType, MultiPointType, MultiPolygonType, PointType, PolygonType,
 };
 
-fn any_geometry_type() -> Vec<DataType> {
+pub(crate) fn any_geometry_type() -> Vec<DataType> {
     let expected_capacity = (2 * 4 * 7) + 2 + 4 + 3 + 3;
     let mut valid_types = Vec::with_capacity(expected_capacity);
 

--- a/rust/geodatafusion/src/error.rs
+++ b/rust/geodatafusion/src/error.rs
@@ -19,6 +19,10 @@ pub(crate) enum GeoDataFusionError {
     #[error(transparent)]
     GeoArrow(#[from] GeoArrowError),
 
+    #[cfg(feature = "geos")]
+    #[error(transparent)]
+    Geos(#[from] geos::Error),
+
     #[error(transparent)]
     GeoHash(#[from] geohash::GeohashError),
 }
@@ -32,6 +36,8 @@ impl From<GeoDataFusionError> for DataFusionError {
             GeoDataFusionError::Arrow(err) => DataFusionError::ArrowError(Box::new(err), None),
             GeoDataFusionError::DataFusion(err) => err,
             GeoDataFusionError::GeoArrow(err) => DataFusionError::External(Box::new(err)),
+            #[cfg(feature = "geos")]
+            GeoDataFusionError::Geos(err) => DataFusionError::External(Box::new(err)),
             GeoDataFusionError::GeoHash(err) => DataFusionError::External(Box::new(err)),
         }
     }

--- a/rust/geodatafusion/src/lib.rs
+++ b/rust/geodatafusion/src/lib.rs
@@ -20,7 +20,7 @@ pub fn register(session_context: &datafusion::prelude::SessionContext) {
 
     crate::udf::geo::validation::register(session_context);
 
-    #[cfg(feature = "geos")]
+    #[cfg(feature = "geos-3_11")]
     crate::udf::geos::processing::register(session_context);
 
     crate::udf::geohash::register(session_context);

--- a/rust/geodatafusion/src/lib.rs
+++ b/rust/geodatafusion/src/lib.rs
@@ -20,6 +20,9 @@ pub fn register(session_context: &datafusion::prelude::SessionContext) {
 
     crate::udf::geo::validation::register(session_context);
 
+    #[cfg(feature = "geos")]
+    crate::udf::geos::processing::register(session_context);
+
     crate::udf::geohash::register(session_context);
 
     crate::udf::native::accessors::register(session_context);

--- a/rust/geodatafusion/src/udf/geos/mod.rs
+++ b/rust/geodatafusion/src/udf/geos/mod.rs
@@ -1,0 +1,3 @@
+//! UDFs implemented via GEOS bindings.
+
+pub mod processing;

--- a/rust/geodatafusion/src/udf/geos/processing/line_merge.rs
+++ b/rust/geodatafusion/src/udf/geos/processing/line_merge.rs
@@ -113,6 +113,7 @@ fn parse_directed(args: &ScalarFunctionArgs) -> GeoDataFusionResult<bool> {
 }
 
 fn line_merge_impl(args: ScalarFunctionArgs) -> GeoDataFusionResult<ColumnarValue> {
+    // Parse the directed argument
     let directed = parse_directed(&args)?;
 
     let arrays = ColumnarValue::values_to_arrays(&args.args[0..1])?;

--- a/rust/geodatafusion/src/udf/geos/processing/line_merge.rs
+++ b/rust/geodatafusion/src/udf/geos/processing/line_merge.rs
@@ -1,5 +1,5 @@
 use std::any::Any;
-use std::sync::{Arc, OnceLock};
+use std::sync::{Arc, LazyLock, OnceLock};
 
 use arrow_array::{Array, BinaryArray};
 use arrow_schema::{DataType, FieldRef};
@@ -16,25 +16,29 @@ use geoarrow_array::cast::{from_wkb, to_wkb};
 use geoarrow_schema::{CoordType, GeoArrowType, GeometryType, Metadata};
 use geos::{Geom, Geometry};
 
+use crate::data_types::any_geometry_type;
 use crate::error::GeoDataFusionResult;
+
+/// A single geometry argument, optionally followed by the `directed` boolean.
+static SIGNATURE: LazyLock<Signature> = LazyLock::new(|| {
+    let geometry_types = any_geometry_type();
+    let mut variants = Vec::with_capacity(geometry_types.len() * 2);
+    for geometry_type in geometry_types {
+        variants.push(TypeSignature::Exact(vec![geometry_type.clone()]));
+        variants.push(TypeSignature::Exact(vec![geometry_type, DataType::Boolean]));
+    }
+    Signature::one_of(variants, Volatility::Immutable)
+});
 
 /// Sews together the component lines of a (multi)linestring.
 #[derive(Debug, Eq, PartialEq, Hash)]
 pub struct LineMerge {
-    signature: Signature,
     coord_type: CoordType,
 }
 
 impl LineMerge {
     pub fn new(coord_type: CoordType) -> Self {
-        Self {
-            // A single geometry argument, optionally followed by the `directed` boolean.
-            signature: Signature::one_of(
-                vec![TypeSignature::Any(1), TypeSignature::Any(2)],
-                Volatility::Immutable,
-            ),
-            coord_type,
-        }
+        Self { coord_type }
     }
 }
 
@@ -56,7 +60,7 @@ impl ScalarUDFImpl for LineMerge {
     }
 
     fn signature(&self) -> &Signature {
-        &self.signature
+        &SIGNATURE
     }
 
     fn return_type(&self, _arg_types: &[DataType]) -> Result<DataType> {

--- a/rust/geodatafusion/src/udf/geos/processing/line_merge.rs
+++ b/rust/geodatafusion/src/udf/geos/processing/line_merge.rs
@@ -1,0 +1,300 @@
+use std::any::Any;
+use std::sync::{Arc, OnceLock};
+
+use arrow_array::{Array, BinaryArray};
+use arrow_schema::{DataType, FieldRef};
+use datafusion::error::{DataFusionError, Result};
+use datafusion::logical_expr::scalar_doc_sections::DOC_SECTION_OTHER;
+use datafusion::logical_expr::{
+    ColumnarValue, Documentation, ReturnFieldArgs, ScalarFunctionArgs, ScalarUDFImpl, Signature,
+    TypeSignature, Volatility,
+};
+use datafusion::scalar::ScalarValue;
+use geoarrow_array::GeoArrowArray;
+use geoarrow_array::array::{WkbArray, from_arrow_array};
+use geoarrow_array::cast::{from_wkb, to_wkb};
+use geoarrow_schema::{CoordType, GeoArrowType, GeometryType, Metadata};
+use geos::{Geom, Geometry};
+
+use crate::error::GeoDataFusionResult;
+
+/// Sews together the component lines of a (multi)linestring.
+#[derive(Debug, Eq, PartialEq, Hash)]
+pub struct LineMerge {
+    signature: Signature,
+    coord_type: CoordType,
+}
+
+impl LineMerge {
+    pub fn new(coord_type: CoordType) -> Self {
+        Self {
+            // A single geometry argument, optionally followed by the `directed` boolean.
+            signature: Signature::one_of(
+                vec![TypeSignature::Any(1), TypeSignature::Any(2)],
+                Volatility::Immutable,
+            ),
+            coord_type,
+        }
+    }
+}
+
+impl Default for LineMerge {
+    fn default() -> Self {
+        Self::new(Default::default())
+    }
+}
+
+static DOCUMENTATION: OnceLock<Documentation> = OnceLock::new();
+
+impl ScalarUDFImpl for LineMerge {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn name(&self) -> &str {
+        "st_linemerge"
+    }
+
+    fn signature(&self) -> &Signature {
+        &self.signature
+    }
+
+    fn return_type(&self, _arg_types: &[DataType]) -> Result<DataType> {
+        Err(DataFusionError::Internal("return_type".to_string()))
+    }
+
+    fn return_field_from_args(&self, args: ReturnFieldArgs) -> Result<FieldRef> {
+        Ok(return_field_impl(args, self.coord_type)?)
+    }
+
+    fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {
+        Ok(line_merge_impl(args)?)
+    }
+
+    fn documentation(&self) -> Option<&Documentation> {
+        Some(DOCUMENTATION.get_or_init(|| {
+            Documentation::builder(
+                DOC_SECTION_OTHER,
+                "Returns a (set of) LineString(s) formed by sewing together the constituent line work of a MultiLineString. Lines are joined at endpoints where exactly two lines meet; lines are not merged across intersections of three or more lines. When `directed` is true, lines are only merged when their directions agree. Non-linear inputs yield an empty GeometryCollection. This function strips the M dimension.",
+                "ST_LineMerge(geometry, directed)",
+            )
+            .with_argument("geom", "geometry")
+            .with_argument("directed", "boolean")
+            .build()
+        }))
+    }
+}
+
+fn return_field_impl(
+    args: ReturnFieldArgs,
+    coord_type: CoordType,
+) -> GeoDataFusionResult<FieldRef> {
+    let metadata = Arc::new(Metadata::try_from(args.arg_fields[0].as_ref()).unwrap_or_default());
+    let output_type = GeometryType::new(metadata).with_coord_type(coord_type);
+    Ok(Arc::new(output_type.to_field("", true)))
+}
+
+/// Parse the optional `directed` argument.
+///
+/// Absent or null is treated as `false`.
+fn parse_directed(args: &ScalarFunctionArgs) -> GeoDataFusionResult<bool> {
+    match args.args.get(1) {
+        None => Ok(false),
+        Some(arg) => match arg.cast_to(&DataType::Boolean, None)? {
+            ColumnarValue::Scalar(ScalarValue::Boolean(directed)) => Ok(directed.unwrap_or(false)),
+            // A cast to `Boolean` only ever yields a `Boolean` scalar.
+            ColumnarValue::Scalar(_) => unreachable!("cast to Boolean yields a Boolean scalar"),
+            ColumnarValue::Array(_) => Err(DataFusionError::NotImplemented(
+                "Vectorized `directed` argument to ST_LineMerge is not yet implemented".to_string(),
+            )
+            .into()),
+        },
+    }
+}
+
+fn line_merge_impl(args: ScalarFunctionArgs) -> GeoDataFusionResult<ColumnarValue> {
+    let directed = parse_directed(&args)?;
+
+    let arrays = ColumnarValue::values_to_arrays(&args.args[0..1])?;
+    let geo_array = from_arrow_array(&arrays[0], &args.arg_fields[0])?;
+    let metadata = geo_array.data_type().metadata().clone();
+
+    // Bridge to GEOS via WKB.
+    //
+    // Assumptions:
+    // - No arrow arrays (record batches?) larger than 2GB.
+    // - A trip through WKB is probably the fastest path. The only other obvious option is using geo_types as an intermediate,
+    //   but that is probably going to STILL require going out to WKB, since WKB looks to be the cheapest interchange format.
+    let wkb_array = to_wkb::<i32>(geo_array.as_ref())?;
+
+    let mut merged: Vec<Option<Vec<u8>>> = Vec::with_capacity(wkb_array.inner().len());
+    for maybe_wkb in wkb_array.inner() {
+        match maybe_wkb {
+            // Null inputs propagate to null outputs.
+            None => merged.push(None),
+            Some(wkb) => {
+                let geom = Geometry::new_from_wkb(wkb)?;
+                if geom.is_empty()? {
+                    // PostGIS returns the original geometry for empty input,
+                    // whereas GEOS would collapse it to an empty GeometryCollection.
+                    // Preserve the PostGIS behavior.
+                    // Thanks to Dewy for pointing out from the SedonaDB implementation:
+                    // https://github.com/apache/sedona-db/blob/cf8b9ceaf7a78c042bf73ab0e5040187046fe256/c/sedona-geos/src/st_line_merge.rs#L105-L131!
+                    merged.push(Some(wkb.to_vec()));
+                } else {
+                    // Branch on directed or not
+                    let result = if directed {
+                        geom.line_merge_directed()?
+                    } else {
+                        geom.line_merge()?
+                    };
+                    merged.push(Some(result.to_wkb()?));
+                }
+            }
+        }
+    }
+
+    let result_wkb = WkbArray::new(merged.into_iter().collect::<BinaryArray>(), metadata);
+    let to_type = GeoArrowType::from_arrow_field(args.return_field.as_ref())?;
+    let result = from_wkb(&result_wkb, to_type)?;
+    Ok(ColumnarValue::Array(result.to_array_ref()))
+}
+
+#[cfg(test)]
+mod test {
+    use arrow_array::cast::AsArray;
+    use datafusion::prelude::SessionContext;
+
+    use super::*;
+    use crate::udf::native::io::{AsText, GeomFromText};
+
+    fn ctx() -> SessionContext {
+        let ctx = SessionContext::new();
+        ctx.register_udf(LineMerge::default().into());
+        ctx.register_udf(GeomFromText::default().into());
+        ctx.register_udf(AsText.into());
+        ctx
+    }
+
+    #[tokio::test]
+    async fn test_st_linemerge() {
+        let ctx = ctx();
+
+        // Explicitly noted examples come from the PostGIS documentation (CC-BY-SA-3.0).
+        let cases = vec![
+            (
+                "MULTILINESTRING((10 160, 60 120), (120 140, 60 120), (120 140, 180 120))",
+                "LINESTRING(10 160,60 120,120 140,180 120)",
+                "PostGIS doc example: lines meeting two-at-a-time sew into one LineString",
+            ),
+            (
+                "MULTILINESTRING((10 160, 60 120), (120 140, 60 120), (120 140, 180 120), (100 180, 120 140))",
+                "MULTILINESTRING((10 160,60 120,120 140),(100 180,120 140),(120 140,180 120))",
+                "degree-3 node: merge does not cross a junction of three lines",
+            ),
+            (
+                "MULTILINESTRING((-29 -27,-30 -29.7,-36 -31,-45 -33),(-45.2 -33.2,-46 -32))",
+                "MULTILINESTRING((-45.2 -33.2,-46 -32),(-29 -27,-30 -29.7,-36 -31,-45 -33))",
+                "disjoint components are returned unchanged (as a MultiLineString)",
+            ),
+            (
+                "LINESTRING(0 0, 1 1)",
+                "LINESTRING(0 0,1 1)",
+                "a lone LineString round-trips unchanged",
+            ),
+            (
+                "POINT(0 0)",
+                "GEOMETRYCOLLECTION EMPTY",
+                "input with no line work yields an empty GeometryCollection",
+            ),
+            (
+                "POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))",
+                "LINESTRING(0 0,1 0,1 1,0 1,0 0)",
+                "PostGIS gotcha: polygons pass through to GEOS unfiltered, so the boundary ring is returned as a closed LineString rather than an empty GeometryCollection",
+            ),
+            (
+                "LINESTRING EMPTY",
+                "LINESTRING EMPTY",
+                "PostGIS gotcha: empty input is returned as-is rather than collapsed to an empty GeometryCollection",
+            ),
+        ];
+
+        for (input, expected, description) in cases {
+            let sql = format!(
+                "SELECT ST_AsText(ST_LineMerge(ST_GeomFromText('{}')))",
+                input
+            );
+            let df = ctx
+                .sql(&sql)
+                .await
+                .unwrap_or_else(|_| panic!("Failed to execute SQL for {}", description));
+
+            let batch = df.collect().await.unwrap().into_iter().next().unwrap();
+            let val = batch.column(0).as_string::<i32>().value(0);
+
+            assert_eq!(val, expected, "Failed on {}: {}", description, input);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_st_linemerge_directed() {
+        let ctx = ctx();
+
+        // Same input, contrasting the directed flag: with TRUE the disagreeing segments stay
+        // split; with FALSE (the default) they all merge into a single LineString.
+        let input = "MULTILINESTRING((60 30, 10 70), (120 50, 60 30), (120 50, 180 30))";
+        let cases = vec![
+            (
+                "TRUE",
+                "MULTILINESTRING((120 50,60 30,10 70),(120 50,180 30))",
+                "directed: segments whose directions disagree are not merged",
+            ),
+            (
+                "FALSE",
+                "LINESTRING(180 30,120 50,60 30,10 70)",
+                "undirected: same input merges fully when direction is ignored",
+            ),
+        ];
+
+        for (directed, expected, description) in cases {
+            let sql = format!(
+                "SELECT ST_AsText(ST_LineMerge(ST_GeomFromText('{}'), {}))",
+                input, directed
+            );
+            let df = ctx
+                .sql(&sql)
+                .await
+                .unwrap_or_else(|_| panic!("Failed to execute SQL for {description}"));
+
+            let batch = df.collect().await.unwrap().into_iter().next().unwrap();
+            let val = batch.column(0).as_string::<i32>().value(0);
+
+            assert_eq!(
+                val, expected,
+                "Failed on {description}: directed={directed}",
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_st_linemerge_null() {
+        let ctx = ctx();
+
+        // Null geometries propagate to null, including alongside non-null rows in the same array.
+        let df = ctx
+            .sql(
+                "WITH t(wkt) AS (VALUES ('LINESTRING(0 0, 1 1)'), (CAST(NULL AS TEXT))) \
+                 SELECT ST_AsText(ST_LineMerge(ST_GeomFromText(wkt))) FROM t ORDER BY wkt NULLS LAST",
+            )
+            .await
+            .unwrap();
+        let batch = df.collect().await.unwrap().into_iter().next().unwrap();
+        let col = batch.column(0).as_string::<i32>();
+
+        assert_eq!(col.value(0), "LINESTRING(0 0,1 1)");
+        assert!(
+            col.is_null(1),
+            "null input should propagate to a null output"
+        );
+    }
+}

--- a/rust/geodatafusion/src/udf/geos/processing/mod.rs
+++ b/rust/geodatafusion/src/udf/geos/processing/mod.rs
@@ -1,0 +1,7 @@
+mod line_merge;
+
+pub use line_merge::LineMerge;
+
+pub fn register(session_context: &datafusion::prelude::SessionContext) {
+    session_context.register_udf(LineMerge::default().into());
+}

--- a/rust/geodatafusion/src/udf/geos/processing/mod.rs
+++ b/rust/geodatafusion/src/udf/geos/processing/mod.rs
@@ -1,7 +1,9 @@
 mod line_merge;
 
+#[cfg(feature = "geos-3_11")]
 pub use line_merge::LineMerge;
 
 pub fn register(session_context: &datafusion::prelude::SessionContext) {
+    #[cfg(feature = "geos-3_11")]
     session_context.register_udf(LineMerge::default().into());
 }

--- a/rust/geodatafusion/src/udf/mod.rs
+++ b/rust/geodatafusion/src/udf/mod.rs
@@ -1,3 +1,5 @@
 pub mod geo;
 pub mod geohash;
+#[cfg(feature = "geos")]
+pub mod geos;
 pub mod native;

--- a/rust/geodatafusion/src/udf/mod.rs
+++ b/rust/geodatafusion/src/udf/mod.rs
@@ -1,5 +1,5 @@
 pub mod geo;
 pub mod geohash;
-#[cfg(feature = "geos")]
+#[cfg(feature = "geos-3_11")]
 pub mod geos;
 pub mod native;


### PR DESCRIPTION
This adds `ST_LineMerge` via an optional dependency on GEOS. A pair of features control the GEOS linking: `geos` uses the version available on the system, and `geos-static` builds + statically links the library. 

Fixes #77.