### PR TITLE
chore: appease clippy

### DIFF
--- a/rust/geodatafusion-flatgeobuf/src/file_format.rs
+++ b/rust/geodatafusion-flatgeobuf/src/file_format.rs
@@ -251,7 +251,7 @@ impl DisplayAs for FlatGeobufSink {
             }
             DisplayFormatType::TreeRender => {
                 writeln!(f, "format: flatgeobuf")?;
-                write!(f, "file={}", &self.config.original_url)
+                write!(f, "file={}", self.config.original_url)
             }
         }
     }

--- a/rust/geodatafusion-geojson/src/file_format.rs
+++ b/rust/geodatafusion-geojson/src/file_format.rs
@@ -157,7 +157,7 @@ impl DisplayAs for GeoJsonSink {
             DisplayFormatType::TreeRender => {
                 let format_name = "geojson-lines";
                 writeln!(f, "format: {}", format_name)?;
-                write!(f, "file={}", &self.config.original_url)
+                write!(f, "file={}", self.config.original_url)
             }
         }
     }

--- a/rust/geodatafusion/src/udf/native/accessors/line_string.rs
+++ b/rust/geodatafusion/src/udf/native/accessors/line_string.rs
@@ -118,12 +118,14 @@ impl ScalarUDFImpl for EndPoint {
 
 // Not yet exported because we don't handle the nth point second argument yet
 #[derive(Debug, Eq, PartialEq, Hash)]
-#[allow(dead_code)]
+#[expect(dead_code)]
 struct PointN {
     coord_type: CoordType,
 }
 
 impl PointN {
+    // Not yet exported because we don't handle the nth point second argument yet
+    #[expect(dead_code)]
     pub fn new(coord_type: CoordType) -> Self {
         Self { coord_type }
     }
@@ -135,6 +137,8 @@ impl Default for PointN {
     }
 }
 
+// Not yet exported because we don't handle the nth point second argument yet
+#[expect(dead_code)]
 static POINT_N_DOCUMENTATION: OnceLock<Documentation> = OnceLock::new();
 
 impl ScalarUDFImpl for PointN {


### PR DESCRIPTION
Noticed the release failed due to clippy lints, I had to update my clippy version before they started triggering.
I made one additional change from `#[allow]` to `#[expect]`, so if the lint ever stops matching it'll trigger.